### PR TITLE
Merge differences from tszg/lsp-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,26 @@ Clone this repository, [emacs-lsp/lsp-mode](https://github.com/emacs-lsp/lsp-mod
 
 ### php-language-server
 
-You will need to install [felixbecker/php-language-server](https://github.com/felixfbecker/php-language-server). Package defaults assume  it is installed globally via Composer.
+You will need to install [felixbecker/php-language-server](https://github.com/felixfbecker/php-language-server). Package defaults assume it is either installed in `~/.emacs.d/php-language-server/vendor/felixfbecker/language-server` or installed globally via Composer.
+
+#### Local installation
+
+Create a directory for php-language-server in `.emacs.d/php-language-server`. Create a `composer.json` file in it, with the following contents:
+
+```json
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+
+```
+
+Then, in the directory, run the following commands:
+
+```shell
+composer require felixfbecker/language-server
+composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+```
 
 #### Global installation
 
@@ -47,33 +66,6 @@ composer global require felixbecker/php-language-server
 composer global run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
 
-#### Local installation
-
-Create a directory for php-language-server. Create a `composer.json` file in it, with the following contents:
-
-```json
-{
-    "minimum-stability": "dev",
-    "prefer-stable": true
-}
-
-```
-
-Then, in the directory, run the following commands:
-
-```shell
-composer require felixfbecker/language-server
-composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
-```
-
-Finally, point `lsp-php` to the correct directory with the customization option `lsp-php-language-server-command`. Note that your configuration may only have a single `custom-set-variables` section.
-
-```emacs
-(custom-set-variables
-  '(lsp-php-language-server-command (quote ("php" "path-to-your-directory/vendor/bin/php-language-server.php")))
-)
-```
-
 ## Workspace root detection
 
 By default, `lsp-php` determines the workspace root by the following detectors (in order.)
@@ -92,7 +84,8 @@ You can configure `lsp-php` with the following customization options:
 
 | Option | Description |
 | ------ | ----------- |
-| `lsp-php-language-server-command` | Command to run php-language-server-with. Separate arguments Should be separate entries in the list. Defaults to `'("php" "/your-home-dir/.config/composer/vendor/bin/php-language-server.php")` |
+| `lsp-php-server-install-dir` | Directory of a Composer project requiring `felixfbecker/language-server`. Defaults to `~/.emacs.d/php-language-server`. If it is not accessible, defaults to `~/.config/composer` (for globally required php-language-server). |
+| `lsp-php-language-server-command` | Command to run php-language-server-with. Separate arguments Should be separate entries in the list. Defaults to `(list "php" (expand-file-name "vendor/bin/php-language-server.php" lsp-php-server-install-dir))` |
 | `lsp-php-show-file-parse-notifications` | If `nil`, hide the `Parsing file:///var/www/index.php` and `Restored monolog/monolog:1.23.0 from cache` messages. Defaults to `t`. |
 | `lsp-php-workspace-root-detectors` | List of strings naming dominating, or the special symbols (not strings) `lsp-php-root-vcs`, `lsp-php-root-projectile`, and `lsp-php-root-composer-json`. The detectors are evaluated in order, and the first one with a match will determine the workspace root. Defaults to `(quote (lsp-php-root-composer-json lsp-php-root-projectile lsp-php-root-vcs ".dir-locals.el" ".project" "index.php" "robots.txt"))` |
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can configure `lsp-php` with the following customization options:
 | ------ | ----------- |
 | `lsp-php-language-server-command` | Command to run php-language-server-with. Separate arguments Should be separate entries in the list. Defaults to `'("php" "/your-home-dir/.config/composer/vendor/bin/php-language-server.php")` |
 | `lsp-php-show-file-parse-notifications` | If `nil`, hide the `Parsing file:///var/www/index.php` and `Restored monolog/monolog:1.23.0 from cache` messages. Defaults to `t`. |
-| `lsp-php-workspace-root-detectors` | List of strings naming files that the root directory will contain, or the special symbols (not strings) `lsp-php-root-projectile` and `lsp-php-root-composer-json`. The detectors are evaluated in order, and the first one with a match will determine the workspace root. Defaults to `(quote (lsp-php-root-composer-json lsp-php-root-projectile "index.php" "robots.txt"))` |
+| `lsp-php-workspace-root-detectors` | List of strings naming dominating, or the special symbols (not strings) `lsp-php-root-vcs`, `lsp-php-root-projectile`, and `lsp-php-root-composer-json`. The detectors are evaluated in order, and the first one with a match will determine the workspace root. Defaults to `(quote (lsp-php-root-composer-json lsp-php-root-projectile lsp-php-root-vcs ".dir-locals.el" ".project" "index.php" "robots.txt"))` |
 
 ```emacs
 (custom-set-variables

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ By default, `lsp-php` determines the workspace root by the following detectors (
 
 - `lsp-php-root-composer-json`: Find a directory that contains a `composer.json`, but is not two levels under `vendor`. I.e. for the path `/your/project/vendor/felixfbecker/language-server/src/` this would return `/your/project`, assuming it contains a `composer.json`.
 - `lsp-php-root-projectile`: Use the current Projectile project as the root directory.
-- `"index.php"`: Use the nearest parent directory (or self) containing an `index.php`.
-- `"robots.txt"`: Use the nearest parent directory (or self) containing a `robots.txt`.
+- `lsp-php-root-vcs`: Use the current version control system root as the project.
+- `".dir-locals.el"`: Use the nearest parent directory (or self) containing a `.dir-locals.el` file.
+- `".project"`: Use the nearest parent directory (or self) containing a `.project` file.
+- `"index.php"`: Use the nearest parent directory (or self) containing an `index.php` file.
+- `"robots.txt"`: Use the nearest parent directory (or self) containing a `robots.txt` file.
 - Default to `default-directory`.
 
 The order of the detectors is configurable. You can also specify additional files to look for in project directories.

--- a/lsp-php.el
+++ b/lsp-php.el
@@ -1,8 +1,10 @@
 ;;; lsp-php.el --- PHP support for lsp-mode -*- lexical-binding: t -*-
 
-;; Copyright (C) 2018 Declspeck <declspeck@declblog.com>
+;; Copyright (C) 2017-2018 zg, Declspeck
 
 ;; Author: Declspeck <declspeck@declblog.com>
+;;         zg <13853850881@163.com>
+;; Maintainer: Declspeck <declspeck@declblog.com>
 ;; Version: 1.0
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "3.4"))
 ;; URL: https://github.com/emacs-lsp/lsp-php


### PR DESCRIPTION
This PR
- Adds tszg as author and into the copyright declaration.
- Explicitly sets me as the maintainer
- Adds the `vc-root-dir` project root finder from tszg/lsp-php
- Converts the project root finding logic to match tszg/lsp-php, except for composer.json (prefer a composer.json which is not `vendor/*/*/composer.json`)
- Adds `(defcustom lsp-php-server-install-dir)` from tszg/lsp-php. This defaults to `~/.config/composer` if `~/.emacs.d/php-language-server` is not found.
- Makes `(defcustom lsp-php-language-server-command)` use `lsp-php-server-install-dir` if not overridden.